### PR TITLE
Week01 노원희 문제 풀이 PR

### DIFF
--- a/week01/CuttingWood.java
+++ b/week01/CuttingWood.java
@@ -1,0 +1,42 @@
+package week01;
+
+import java.util.Arrays;
+
+public class CuttingWood {
+    public static int cuttingWood(int[] heights, int k) {
+        int bottom, top;
+        bottom = 0;
+        top = getTallestHeight(heights);
+
+        while (top > bottom) {
+            int mid = bottom + (top - bottom) / 2 + 1;  // upper-bound
+
+            if (yieldsEnoughWood(heights, mid, k)) {
+                bottom = mid;
+            }
+            else {
+                top = mid - 1;
+            }
+        }
+
+        return top;
+    }
+
+    private static boolean yieldsEnoughWood(int[] heights, int H, int k) {
+        int woodCollected = 0;
+        for (int height : heights) {
+            if (height > H) {
+                woodCollected += height - H;
+            }
+        }
+
+        return woodCollected >= k;
+    }
+
+    static int getTallestHeight(int[] heights) {
+        if (heights == null || heights.length == 0)
+            return 0;
+
+        return Arrays.stream(heights).max().getAsInt();
+    }
+}

--- a/week01/FindTheTargetInARotatedSortedArray.java
+++ b/week01/FindTheTargetInARotatedSortedArray.java
@@ -1,0 +1,36 @@
+package week01;
+
+public class FindTheTargetInARotatedSortedArray {
+    public static int findTheTargetInARotatedSortedArray(int[] nums, int target) {
+        if (nums == null || nums.length == 0) return -1;
+
+        int left, right;
+        left = 0;
+        right = nums.length - 1;
+
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+
+            if (nums[mid] == target)
+                return mid;
+
+            // mid를 기준으로 왼쪽/오른쪽 중 한 쪽은 반드시 ascending order일 것
+            // Case 1: 왼쪽 => ascending order
+            if (nums[left] < nums[mid]) {
+                if (nums[left] <= target && target < nums[mid])
+                    right = mid - 1;
+                else
+                    left = mid + 1;
+            }
+            // Case 2: 오른쪽 => ascending order
+            else {
+                if (nums[mid] < target && target <= nums[right])
+                    left = mid + 1;
+                else
+                    right = mid - 1;
+            }
+        }
+
+        return nums[left] == target ? left : -1;
+    }
+}

--- a/week01/ValidParenthesisExpression.java
+++ b/week01/ValidParenthesisExpression.java
@@ -1,0 +1,31 @@
+package week01;
+
+import java.util.Deque;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ValidParenthesisExpression {
+    public static boolean validParenthesisExpression(String s) {
+        Deque<Character> stack = new ArrayDeque<>();
+        Map<Character, Character> parenthesisMap = new HashMap<>();
+        parenthesisMap.put('[', ']');
+        parenthesisMap.put('{', '}');
+        parenthesisMap.put('(', ')');
+
+        for (char c : s.toCharArray()) {
+            if (parenthesisMap.containsKey(c))
+                stack.push(c);
+            else if (c == ']' || c == '}' || c == ')')
+                if (!stack.isEmpty() && parenthesisMap.get(stack.peek()) == c)
+                    stack.pop();
+                else
+                    return false;
+            else
+                return false;
+        }
+
+        // 모든 opening parenthesis들이 다 닫혔나 final check
+        return stack.isEmpty();
+    }
+}

--- a/week01/test/CuttingWoodTest.java
+++ b/week01/test/CuttingWoodTest.java
@@ -1,0 +1,40 @@
+package week01.test;
+
+import org.junit.jupiter.api.Test;
+import week01.CuttingWood;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CuttingWoodTest {
+    @Test
+    void testBasicCase() {
+        int[] heights = {2, 6, 3, 8};
+        int k = 7;
+        int result = CuttingWood.cuttingWood(heights, k);
+        assertEquals(3, result);    // 0+3+0+5 = 8
+    }
+
+    @Test
+    void testLargerK() {
+        int[] heights = {20, 15, 10, 17};
+        int k = 20;
+        int result = CuttingWood.cuttingWood(heights, k);
+        assertEquals(10, result); // 10+5+0+7 = 22
+    }
+
+    @Test
+    void testZeroRequiredWood() {
+        int[] heights = {4, 5, 6};
+        int k = 0;
+        int result = CuttingWood.cuttingWood(heights, k);
+        assertEquals(6, result);    // 0+0+0 = 0
+    }
+
+    @Test
+    void testAllSameHeight() {
+        int[] heights = {10, 10, 10, 10};
+        int k = 5;
+        int result = CuttingWood.cuttingWood(heights, k);
+        assertEquals(8, result); // 2+2+2+2 =8
+    }
+}

--- a/week01/test/FindTheTargetInARotatedSortedArrayTest.java
+++ b/week01/test/FindTheTargetInARotatedSortedArrayTest.java
@@ -1,0 +1,71 @@
+package week01.test;
+
+import org.junit.jupiter.api.Test;
+import week01.FindTheTargetInARotatedSortedArray;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FindTheTargetInARotatedSortedArrayTest {
+    @Test
+    void testFoundInRotatedArray() {
+        int[] nums = {8, 9, 1, 2, 3, 4, 5, 6, 7};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 1);
+        assertEquals(2, result);
+    }
+
+    @Test
+    void testNotFoundInRotatedArray() {
+        int[] nums = {4, 5, 6, 7, 0, 1, 2};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 3);
+        assertEquals(-1, result);
+    }
+
+    @Test
+    void testFoundAtBeginning() {
+        int[] nums = {6, 7, 8, 1, 2, 3, 4, 5};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 6);
+        assertEquals(0, result);
+    }
+
+    @Test
+    void testFoundAtEnd() {
+        int[] nums = {6, 7, 8, 1, 2, 3, 4, 5};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 5);
+        assertEquals(7, result);
+    }
+
+    @Test
+    void testSortedArrayNoRotation() {
+        int[] nums = {1, 2, 3, 4, 5, 6, 7};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 4);
+        assertEquals(3, result);
+    }
+
+    @Test
+    void testSingleElementFound() {
+        int[] nums = {1};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 1);
+        assertEquals(0, result);
+    }
+
+    @Test
+    void testSingleElementNotFound() {
+        int[] nums = {1};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 2);
+        assertEquals(-1, result);
+    }
+
+    @Test
+    void testEmptyArray() {
+        int[] nums = {};
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 1);
+        assertEquals(-1, result);
+    }
+
+    @Test
+    void testNullArray() {
+        int[] nums = null;
+        int result = FindTheTargetInARotatedSortedArray.findTheTargetInARotatedSortedArray(nums, 1);
+        assertEquals(-1, result);
+    }
+}

--- a/week01/test/ValidParenthesisExpressionTest.java
+++ b/week01/test/ValidParenthesisExpressionTest.java
@@ -1,0 +1,50 @@
+package week01.test;
+
+import org.junit.jupiter.api.Test;
+import week01.ValidParenthesisExpression;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidParenthesisExpressionTest {
+    @Test
+    void testValidCases() {
+        assertTrue(ValidParenthesisExpression.validParenthesisExpression("()"));
+        assertTrue(ValidParenthesisExpression.validParenthesisExpression("()[]{}"));
+        assertTrue(ValidParenthesisExpression.validParenthesisExpression("{[()]}"));
+        assertTrue(ValidParenthesisExpression.validParenthesisExpression("([]{})"));
+        assertTrue(ValidParenthesisExpression.validParenthesisExpression("((({[]})))"));
+    }
+
+    @Test
+    void testInvalidCases() {
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("(]"));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("([)]"));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("((("));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("(()"));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("([]{)}"));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("{[(])}"));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertTrue(ValidParenthesisExpression.validParenthesisExpression(""));
+    }
+
+    @Test
+    void testOnlyOpening() {
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("(((("));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("{["));
+    }
+
+    @Test
+    void testOnlyClosing() {
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("))))"));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("]}"));
+    }
+
+    @Test
+    void testSingleCharacter() {
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("("));
+        assertFalse(ValidParenthesisExpression.validParenthesisExpression("]"));
+    }
+}


### PR DESCRIPTION
# Week01_노원희

## [250326] Cutting Wood
- Binary Search
    - 입력된 배열이 sort 되지 않았는데 어떻게 Binary Search로 푼다는 걸까?
        - 이 문제에서의 search space -- 다른 binary search 문제와 비교했을 때 특이한 편
            - 인덱스(가로) => X
            - 나무 높이(세로) => O
    - 1. search space => 0 ~ 나무 최고 높이
    - 2. search space 줄여나가기
        - 이 문제는 높이(H)의 "upper"-bound를 구해야 함
            - mid = bottom + (top - bottom) / 2 + 1
        - 해당 높이가 충분한(k 이상의) 나무를 도출하는지 판단하기
            => 함수 yieldsEnoughWood
            - 해당 높이(H)가 k 이상의 나무를 도출하는지 판단하는 함수
            - H에 따른 yieldsEnoughWood의 결과를 '시각화'해보면
                - (true) -> (false)
                - "sorted"
                - 특정 condition에 대한 충족 여부에 따라 '이분화(binary)'되어 분류됨
        - 1. condition 충족 시; 나무 양 >= k
            => bottom = mid
            - mid 포함 O
        - 2. condition 불만족 시; 나무 양 < k
            => top = mid - 1
            - mid 포함 X
- 시간복잡도: O(N * log(M))
- 공간복잡도: O(1)

## [250327] Find the Target in a Rotated Sorted Array
- Binary Search > Partially Sorted Arrays
    - vs. naive solution
        - target number 찾을 때까지 배열을 iterate 하기
        - 단점
            - 시간복잡도 => linear time 소요
            - 입력 배열이 rotated sorted array 라는 사실을 전혀 고려하지 않은 방식
    - "sorted" before the input array was rotated ==> Binary Search 를 사용하자!
    - 1. define the search space
        => entire array
    - 2. narrow the search space
        - 특이점: 배열이 '완전히' sort된 상태가 아니라는 점
        - normal sorted array vs. rotated sorted array
            - normal sorted array
                - 왼쪽 또는 오른쪽으로 search space 를 줄여나가는 기준 => 오로지 midpoint & target
            - rotated sorted array
                - 왼쪽 또는 오른쪽으로 search space 를 줄여나가는 기준 => midpoint & target + left, right
                - 배열 안의 숫자들을 높이로 '시각화'해보고, mid를 기준으로 왼쪽 / 오른쪽을 구분해서 잘 살펴보면 큰 힌트를 얻을 수 있다.
                    - mid를 기준으로 왼쪽/오른쪽 중 한 쪽은 반드시 ascending order 이다.
    - 3. 나머지 예외처리
        - 수렴된 값이 target과 다를 경우 => -1 반환
        - 수렴된 값이 target과 같을 경우 => 해당 인덱스 반환
- 시간복잡도: O(log N)
- 공간복잡도: O(1)

## [250328] Valid Parenthesis Expression
- Stacks
    - stack의 메인 연산 (2가지)
        - push (맨 위에 추가)
        - pop (맨 위 제거)
    - LIFO (Last-In-First-Out)
        - stack => '처리' 또는 '삭제'의 순서가 중요한 시나리오에서 유용한 자료구조
            - Nested Structures 다루기
                - e.g. 문자열의 nested parentheses 다루기
                    - 가장 안쪽의 nested structures부터 먼저 처리한다.
            - Reverse order
                - e.g. 배열의 reversing
            - Substitute for recursion
                - recursive call stack
                - recursive functions를 반복적(iteratively)으로 구현 가능
            - Monotonic stacks
                - 특별한 목적으로, 일정한 순서(증가/감소)에 따라 정렬하는 시나리오
    - 시간복잡도
        - push => O(1)
        - pop => O(1)
        - peek => O(1)
        - isEmpty => O(1)
    - 실세계 예제
        - Function call management
            - 함수들이 올바른 순서에 따라 제어하여, nested 또는 recursive 함수 호출을 효율적으로 관리한다.
            - function call stack에 함수의 상태(state; parameters, local variables, return address 등)을 저장한다.

- Stacks > Nested Structures
    - 고려사항: 'opening 괄호와 closing 괄호의 개수 (동일해야 함)' + '괄호들의 순서'
    - 괄호들의 순서
        - 가장 최근의 opening 괄호가 가장 먼저 close 되어야 한다.
        - LIFO (Last-In-First-Out)
        - stack
- 이 문제의 전략
    - opening 괄호를 만난다면 => stack에 추가
        - 가장 최근에 넣은 괄호가 stack의 가장 위에 위치하게 됨
    - closing 괄호를 만난다면 => 이걸로 가장 최근의 opening 괄호를 닫을 수 있는지 체크
        - 닫을 수 있다면 => stack에서 제거
        - 닫을 수 없다면 => invalid 반환
- 예외처리: opening 괄호가 남는 경우
    - invalidity에 대한 체크 작업은 closing 괄호를 만났을 때만 이루어진다.
    - 따라서 모든 작업이 끝나고도 stack이 비어있는지 final check 필요
- 괄호의 타입 관리
    - Hash Map 사용
        - 적합한 opening 괄호와 closing 괄호를 매칭시켜놓기
        - 특정 괄호가 opening 괄호인지, closing 괄호인지 체크도 가능
- 시간복잡도: O(N)
- 공간복잡도
    - stack의 경우 => O(N) -- opening 괄호의 개수에 따라 달라질 것
    - hash map의 경우 => O(1) -- 상수