### PR TITLE
[Week02] 노원희 문제 풀이 PR

### DIFF
--- a/datatype/ListNode.java
+++ b/datatype/ListNode.java
@@ -1,0 +1,45 @@
+package datatype;
+
+import java.util.Objects;
+
+public class ListNode {
+    public int val;
+    public ListNode next;
+
+    public ListNode() {
+        this.val = Integer.MIN_VALUE;
+    }
+
+    public ListNode(int val) {
+        this.val = val;
+    }
+
+    public ListNode(int val, ListNode next) {
+        this.val = val;
+        this.next = next;
+    }
+
+    public static ListNode createList(int... values) {
+        ListNode head = new ListNode(values[0]);
+        ListNode prev = head;
+        for (int i = 1; i < values.length; i++) {
+            prev.next = new ListNode(values[i]);
+            prev = prev.next;
+        }
+        return head;
+    }
+
+    @Override
+    public String toString() {
+        return val + "->" + next;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListNode listNode = (ListNode) o;
+        return val == listNode.val &&
+                Objects.equals(next, listNode.next);
+    }
+}

--- a/week02/EvaluateExpression.java
+++ b/week02/EvaluateExpression.java
@@ -1,0 +1,39 @@
+package week02;
+
+import java.util.*;
+
+public class EvaluateExpression {
+    public static int evaluateExpression(String s) {
+        Deque<Integer> stack = new ArrayDeque<>();
+        int res = 0;
+        int sign = 1;
+        int currNum = 0;
+
+        for (char c : s.toCharArray()) {
+            if (Character.isDigit(c))
+                currNum = currNum * 10 + (c - '0');
+            else if (c == '+' || c == '-') {
+                res += sign * currNum;
+
+                sign = (c == '+') ? 1 : -1;
+                currNum = 0;
+            }
+            else if (c == '(') {
+                stack.push(res);
+                stack.push(sign);
+                res = 0;
+                sign = 1;
+            }
+            else if (c == ')') {
+                res += sign * currNum;
+
+                res *= stack.pop();
+                res += stack.pop();
+
+                currNum = 0;
+            }
+        }
+
+        return res + sign * currNum;
+    }
+}

--- a/week02/KMostFrequentStrings_MaxHeap.java
+++ b/week02/KMostFrequentStrings_MaxHeap.java
@@ -1,0 +1,51 @@
+package week02;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+public class KMostFrequentStrings_MaxHeap {
+    public static class Pair implements Comparable<Pair> {
+        String str;
+        int freq;
+
+        public Pair(String str, int freq) {
+            this.str = str;
+            this.freq = freq;
+        }
+
+        @Override
+        public int compareTo(Pair other) {
+            if (this.freq == other.freq) {
+                // reverse lexicographical order
+                return other.str.compareTo(this.str);
+            }
+
+            // lower-frequency order
+            return Integer.compare(this.freq, other.freq);
+        }
+    }
+
+    public static List<String> kMostFrequentStringsMaxHeap(String[] strs, int k) {
+        List<String> result = new ArrayList<>();
+
+        Map<String, Integer> freqs = new HashMap<>();
+        for (String str : strs)
+            freqs.put(str, freqs.getOrDefault(str, 0) + 1);
+
+        PriorityQueue<Pair> maxHeap = new PriorityQueue<>(Comparator.reverseOrder());
+
+        for (Map.Entry<String, Integer> entry : freqs.entrySet()) {
+            maxHeap.add(new Pair(entry.getKey(), entry.getValue()));
+        }
+
+        for (int i = 0; i < k && !maxHeap.isEmpty(); i++) {
+            result.add(maxHeap.poll().str);
+        }
+
+        return result;
+    }
+}

--- a/week02/KMostFrequentStrings_MinHeap.java
+++ b/week02/KMostFrequentStrings_MinHeap.java
@@ -1,0 +1,54 @@
+package week02;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+public class KMostFrequentStrings_MinHeap {
+    static class Pair implements Comparable<Pair> {
+        String str;
+        int freq;
+
+        public Pair(String str, int freq) {
+            this.str = str;
+            this.freq = freq;
+        }
+
+        @Override
+        public int compareTo(Pair other) {
+            if (this.freq == other.freq) {
+                // reverse lexicographical order
+                return other.str.compareTo(this.str);
+            }
+
+            // lower-frequency order
+            return Integer.compare(this.freq, other.freq);
+        }
+    }
+
+    public static List<String> kMostFrequentStringsMinHeap(String[] strs, int k) {
+        List<String> result = new ArrayList<>();
+
+        Map<String, Integer> freqs = new HashMap<>();
+        for (String str : strs)
+            freqs.put(str, freqs.getOrDefault(str, 0) + 1);
+
+        PriorityQueue<Pair> minHeap = new PriorityQueue<>();
+        for (Map.Entry<String, Integer> entry : freqs.entrySet()) {
+            minHeap.add(new Pair(entry.getKey(), entry.getValue()));
+
+            if (minHeap.size() > k)
+                minHeap.poll();
+        }
+
+        while (!minHeap.isEmpty())
+            result.add(minHeap.poll().str);
+
+        Collections.reverse(result);
+
+        return result;
+    }
+}

--- a/week02/NextLargestNumberToTheRight.java
+++ b/week02/NextLargestNumberToTheRight.java
@@ -1,0 +1,27 @@
+package week02;
+
+import java.util.Deque;
+import java.util.ArrayDeque;
+
+public class NextLargestNumberToTheRight {
+    public static int[] nextLargestNumberToTheRight(int[] nums) {
+        int[] res = new int[nums.length];
+        Deque<Integer> candidates = new ArrayDeque<>();
+
+        // 왼쪽이 아닌 '오른쪽'부터 탐색
+        for (int i = nums.length - 1; i >= 0; i--) {
+            // 1. 현재 막대의 추가로 인해 자격을 잃게 되는 candidate들 제거하기
+            while (!candidates.isEmpty() && nums[i] >= candidates.peek())
+                candidates.pop();
+
+            // 2. 현재 막대의 next largest number to the right 기록하기
+            res[i] = candidates.isEmpty() ? -1 : candidates.peek();
+
+            // 3. 현재 막대를 새로운 candidate로 추가하기
+            candidates.push(nums[i]);
+        }
+
+        return res;
+    }
+}
+

--- a/week02/test/EvaluateExpressionTest.java
+++ b/week02/test/EvaluateExpressionTest.java
@@ -1,0 +1,50 @@
+package week02.test;
+
+import org.junit.jupiter.api.Test;
+import week02.EvaluateExpression;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EvaluateExpressionTest {
+    @Test
+    void testSingleNumber() {
+        assertEquals(42, EvaluateExpression.evaluateExpression("42"));
+    }
+
+    @Test
+    void testSimpleAddition() {
+        assertEquals(3, EvaluateExpression.evaluateExpression("1+2"));
+    }
+
+    @Test
+    void testAdditionAndSubtraction() {
+        assertEquals(5, EvaluateExpression.evaluateExpression("4-1+2"));
+    }
+
+    @Test
+    void testJustParentheses() {
+        assertEquals(1, EvaluateExpression.evaluateExpression("(1)"));
+        assertEquals(3, EvaluateExpression.evaluateExpression("(1+(2))"));
+    }
+
+    @Test
+    void testWithSingleParentheses() {
+        assertEquals(2, EvaluateExpression.evaluateExpression("1-(2-3)"));
+    }
+
+    @Test
+    void testWithNestedParentheses() {
+        assertEquals(13, EvaluateExpression.evaluateExpression("18-(7+(2-4))"));
+        assertEquals(2, EvaluateExpression.evaluateExpression("7+6-(3+(4-5)+8)-1"));
+    }
+
+    @Test
+    void testWithWhitespace() {
+        assertEquals(7, EvaluateExpression.evaluateExpression(" 2 + ( 3 + 2 ) "));
+    }
+
+    @Test
+    void testNegativeResult() {
+        assertEquals(-4, EvaluateExpression.evaluateExpression("1-(2+3)"));
+    }
+}

--- a/week02/test/KMostFrequentStringsTest.java
+++ b/week02/test/KMostFrequentStringsTest.java
@@ -1,0 +1,79 @@
+package week02.test;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import week02.KMostFrequentStrings_MaxHeap;
+import week02.KMostFrequentStrings_MinHeap;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KMostFrequentStringsTest {
+
+    @Nested
+    class MaxHeapTests {
+        @Test
+        void testBasicCase() {
+            String[] strs = {"go", "coding", "byte", "byte", "go", "interview", "go"};
+            int k = 2;
+            List<String> expected = List.of("go", "byte");
+            List<String> actual = KMostFrequentStrings_MaxHeap.kMostFrequentStringsMaxHeap(strs, k);
+
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void testSameFrequencyDifferentLexOrder() {
+            String[] input = {"dog", "cat", "dog", "cat", "hamster"};
+            int k = 2;
+            List<String> expected = List.of("cat", "dog");
+            List<String> actual = KMostFrequentStrings_MaxHeap.kMostFrequentStringsMaxHeap(input, k);
+
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void testSingleElement() {
+            String[] input = {"onlyone"};
+            int k = 1;
+            List<String> expected = List.of("onlyone");
+            List<String> actual = KMostFrequentStrings_MaxHeap.kMostFrequentStringsMaxHeap(input, k);
+
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Nested
+    class MinHeapTests {
+        @Test
+        void testBasicCase() {
+            String[] strs = {"go", "coding", "byte", "byte", "go", "interview", "go"};
+            int k = 2;
+            List<String> expected = List.of("go", "byte");
+            List<String> actual = KMostFrequentStrings_MinHeap.kMostFrequentStringsMinHeap(strs, k);
+
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void testSameFrequencyDifferentLexOrder() {
+            String[] input = {"dog", "cat", "dog", "cat", "hamster"};
+            int k = 2;
+            List<String> expected = List.of("cat", "dog");
+            List<String> actual = KMostFrequentStrings_MinHeap.kMostFrequentStringsMinHeap(input, k);
+
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void testSingleElement() {
+            String[] input = {"onlyone"};
+            int k = 1;
+            List<String> expected = List.of("onlyone");
+            List<String> actual = KMostFrequentStrings_MinHeap.kMostFrequentStringsMinHeap(input, k);
+
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/week02/test/NextLargestNumberToTheRightTest.java
+++ b/week02/test/NextLargestNumberToTheRightTest.java
@@ -1,0 +1,56 @@
+package week02.test;
+
+import org.junit.jupiter.api.Test;
+import week02.NextLargestNumberToTheRight;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NextLargestNumberToTheRightTest {
+    @Test
+    void testGeneralCase() {
+        int[] nums = {5, 2, 4, 6, 1};
+        int[] result = NextLargestNumberToTheRight.nextLargestNumberToTheRight(nums);
+        int[] expected = {6, 4, 6, -1, -1};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testAllIncreasing() {
+        int[] nums = {1, 2, 3, 4, 5};
+        int[] result = NextLargestNumberToTheRight.nextLargestNumberToTheRight(nums);
+        int[] expected = {2, 3, 4, 5, -1};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testAllDecreasing() {
+        int[] nums = {5, 4, 3, 2, 1};
+        int[] result = NextLargestNumberToTheRight.nextLargestNumberToTheRight(nums);
+        int[] expected = {-1, -1, -1, -1, -1};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testWithDuplicates() {
+        int[] nums = {1, 3, 2, 3, 1};
+        int[] result = NextLargestNumberToTheRight.nextLargestNumberToTheRight(nums);
+        int[] expected = {3, -1, 3, -1, -1};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testSingleElement() {
+        int[] nums = {10};
+        int[] result = NextLargestNumberToTheRight.nextLargestNumberToTheRight(nums);
+        int[] expected = {-1};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testEmptyArray() {
+        int[] nums = {};
+        int[] result = NextLargestNumberToTheRight.nextLargestNumberToTheRight(nums);
+        int[] expected = {};
+        assertArrayEquals(expected, result);
+    }
+}

--- a/week03/CombineSortedLinkedList.java
+++ b/week03/CombineSortedLinkedList.java
@@ -1,0 +1,27 @@
+package week03;
+
+import datatype.ListNode;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class CombineSortedLinkedList {
+    public static ListNode combineSortedLinkedLists(List<ListNode> lists) {
+        PriorityQueue<ListNode> minHeap = new PriorityQueue<>(Comparator.comparingInt(self -> self.val));
+        for (ListNode head : lists)
+            if (head != null) minHeap.offer(head);
+
+        ListNode dummy = new ListNode(-1);
+        ListNode currNode = dummy;
+        while (!minHeap.isEmpty()) {
+            ListNode smallestNode = minHeap.poll();
+            currNode.next = smallestNode;
+            currNode = currNode.next;
+            if (smallestNode.next != null)
+                minHeap.offer(smallestNode.next);
+        }
+
+        return dummy.next;
+    }
+}

--- a/week03/test/CombineSortedLinkedListTest.java
+++ b/week03/test/CombineSortedLinkedListTest.java
@@ -1,0 +1,58 @@
+package week03.test;
+
+import datatype.ListNode;
+import org.junit.jupiter.api.Test;
+import week03.CombineSortedLinkedList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CombineSortedLinkedListTest {
+    @Test
+    void testBasicCase() {
+        ListNode ln1 = ListNode.createList(1, 6);
+        ListNode ln2 = ListNode.createList(1, 4, 6);
+        ListNode ln3 = ListNode.createList(3, 7);
+
+        List<ListNode> lists = List.of(ln1, ln2, ln3);
+        ListNode actual = CombineSortedLinkedList.combineSortedLinkedLists(lists);
+
+        ListNode expected = ListNode.createList(1, 1, 3, 4, 6, 6, 7);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testEmptyLists() {
+        ListNode ln1 = null;
+        ListNode ln2 = null;
+
+        List<ListNode> lists = new ArrayList<>();
+        lists.add(ln1);
+        lists.add(ln2);
+
+        ListNode result = CombineSortedLinkedList.combineSortedLinkedLists(lists);
+        assertNull(result);
+    }
+
+    @Test
+    void testSingleListOnly() {
+        ListNode l1 = ListNode.createList(1, 2, 3);
+
+        List<ListNode> lists = List.of(l1);
+        ListNode actual = CombineSortedLinkedList.combineSortedLinkedLists(lists);
+
+        ListNode expected = ListNode.createList(1, 2, 3);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testAllListsEmpty() {
+        List<ListNode> lists = List.of();
+        ListNode result = CombineSortedLinkedList.combineSortedLinkedLists(lists);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
# Week02_노원희

## [250331] Next Largest Number to the Right

- Stacks > Monotonic Stack
    - 문제의 요구사항
        - 각 값의 next largest number to the right를 찾아라
    - "사고의 전환"
        - 현재 값이 그 왼쪽 값들 중 어떠한 값의 next largest number가 될 수 있는가 체크해보자!
        - "candidates" 개념의 도입
        - 왼쪽이 아닌, '오른쪽'에서 왼쪽으로 탐색을 진행해야 한다.
    - Monotonic Stack
        - 현재 값보다 작거나 같은 candidate들은 더이상 그 어느 왼쪽 값들의 next largest number가 될 수 없다.
            - 즉, 자격을 잃게 되어 candidates에서 제거되게 된다.
        - 최종적인 candidates의 모양: "strictly(monotonic) decreasing order"
    - 풀이 순서
        - 1. 현재 막대의 추가로 인해 자격을 잃게 되는 candidate들 "제거"하기; pop()
            - 이로써 자격이 되는 현재 막대의 next largest number to the right가 `candidates` stack의 맨 위에 오게 됨
            - 자격 조건: 현대 막대의 길이 < candidate 길이
        - 2. 현재 막대의 next largest number to the right 기록하기
            - 현재 막대의 next largest number to the right => candidates stack의 맨 위
            - 이때, 만약 candidates stack에 아무도 없다면 => -1
        - 3. 현재 막대를 새로운 candidate로 "추가"하기; push()
- 시간복잡도: O(N)
    - vs. 브루트포스 방식: O(N^2)
- 공간복잡도: O(N)

- vs. 1차 시도
    - '왼쪽'부터 순차적으로 접근함
    - 본인보다 큰 막대 마주치기 전까지 스택에 대기시켜뒀다가, 마주치는 순간 그 항목의 인덱스에 지금 마주친 막대의 길이 저장
    - 장점
        - 시간복잡도: O(N)
        - 모든 테스트를 통과하긴 함
    - 단점
        - '인덱스' 저장이 필요하게 됨.
            - 대기시켜둔 항목의 인덱스를 통해 지금 마주친 막대의 크기를 저장하러 가야하기 때문.
        - '인덱스'도 저장하기 위해 Element라는 클래스를 임의로 만들게 됨.
        - stack에 Element라는 '객체'를 저장하기 때문에 같은 공간복잡도더라도 더 무거움.
        - 덜 직관적임. 오른쪽에 있는 다음 큰 숫자를 찾는 과정에 '대기' 스택을 둔다는 게 덜 직관적으로 느껴질 수 있을 듯.
    - 결론
        - stack을 사용해 푼 건 좋았음.
        - 하지만 2차 시도가 1차 시도의 모든 단점을 해결한다는 점에서 2차 시도가 더 최적화된 풀이 방법임.

## [250402] Evaluate Expression

- Stacks > Nested Structures
    - expression => 복합적인 element들이 포함되어있는 상태
        - '복합적인 element들'이란?
            - 음수
            - 괄호 안의 nested expression
            - 여러 자리의 숫자
    - 이 복잡함을 어떻게 해결할 수 있을까?
        - 더 작고, 관리 가능한 정도로 문제를 break down 해서 순차적으로 해결책을 떠올려보자!
        - 복잡한 문제의 break-down steps
            - 1. '여러 자리의 숫자'를 어떻게 처리할 것인가?
            - 2. '연산자'를 어떻게 처리할 것인가?
            - 3. '괄호가 없는' 식을 어떻게 처리할 것인가?
            - 4. '괄호가 있는' 식을 어떻게 처리할 것인가?
    - 1. '여러 자리의 숫자'를 어떻게 처리할 것인가?
        - digit-by-digit으로 숫자를 build 해나가자!
        - 새로운 '숫자'를 마주쳤다면
            - currNum을 building한다.
            - currNum = 기존 currNum * 10 + 새로운 숫자
        - 새로운 '기호'를 마주쳤다면
            - currNum의 building을 멈춘다.
    - 2. '연산자'를 어떻게 처리할 것인가?
        - '뺄셈 또는 덧셈'을 모두 '(pure) 덧셈'으로 처리하자! => '덧셈' 연산을 수행하는 데만 집중하면 됨!
            - '뺄셈 또는 덧셈'의 방식: 1 - 3 + 5 - 2
            - '(pure) 덧셈'의 방식: (+1) + (-3) + (+5) + (-2)
        - (+) 연산자 --> 1 곱하기
        - (-) 연산자 --> -1 곱하기
    - 3. '괄호가 없는' 식을 어떻게 처리할 것인가?
        - 새로운 '연산자'를 마주쳤다면
            - 1) sign 반영
                - sign * currNum
            - 2) (pure) 덧셈
                - res += sign * currNum
            - 3) sign 업데이트
                - sign = -1 또는 1
            - 4) currNum 업데이트
                - currNum = 0
    - 4. '괄호가 있는' 식을 어떻게 처리할 것인가?
        - '괄호'의 등장 => nested expressions 발생 => 아래 2가지 정보를 Stack에 저장해야 함
            - 1) 현재 expression의 `res` (running result)
            - 2) 뒤이어 오는 nested expression의 sign
        - '열린 괄호'를 마주쳤다면
            - 1) Stack에 `res` & `sign` 저장
            - 2) `res` & `sign` 초기화
                - 새로운 expression에 대한 계산을 시작하기 위함
        - '닫힌 괄호'를 마주쳤다면
            - 괄호 안쪽의 결과를 괄호 바깥쪽과 접합(merge)시킨다.
            - 1) sign 반영
                - res *= stack.pop()
            - 2) (pure) 덧셈
                - res += stack.pop()
- 시간복잡도: O(N)
- 공간복잡도: O(N)

## [250405] Finding Values in Sorted Order

### Max Heap ver.

- Heaps > Finding Values in Sorted Order > Max Heap
    - 본 문제의 주요 도전과제
        - 1. 가장 빈번한 문자열 k개를 식별하기
        - 2. 문자열들 정렬하기 (우선순위: 1. frequency, 2. lexicographical)
    - 1. 가장 빈번한 문자열 k개를 식별하기
        - Hash Map 사용
        - 방법 (2가지)
            - 1. Hash Map -> Array -> Array 전체에 대해 내림차순 정렬
                - 비효율적인 방법
                - 본 문제에서는 '모든' element들이 정렬될 필요 없이, 'Top K개'의 element들에 한해서 정렬되면 된다!
            - 2. Max Heap
                - 언제든지 가장 빈번한 문자열에 효율적으로 액세스할 수 있는 데이터 구조
            - cf. Array Sort vs. Max Heap
                - Array Sort
                    - '전체' 정렬
                    - 시간복잡도: O(N log N)
                - Max Heap
                    - '부분' 정렬
                        - `부모 ≥ 자식`라는 규칙에 따라 항상 루트 노드가 최댓값이 되는 Heap 구조만 보장할 뿐
                            - 가장 큰 값만 빠르게 꺼내기에는 최적의 자료구조
                        - 형제 노드들끼리의 순서는 보장하지 않는다.
                    - 시간복잡도: O(N)
                        - sift-down 방식
        - Max Heap
            - 1. Max Heap 생성
                - (문자열, frequency) 저장
                    - Pair 클래스의 도입
                - 생성 방법 (2가지)
                    - 1. 모든 문자열들에 대해 push하기
                        - 비효율적인 방법
                        - 시간복잡도: O(N * log N)
                    - 2. heapify 연산 사용하기
                        - 효율적인 방법
                        - 시간복잡도: O(N)
            - 2. Max Heap에서 Top element를 k번 pop off하기
    - 2. 문자열들 정렬하기 (우선순위: 1. frequency, 2. lexicographical)
        - lexicographical하게 정렬 시 => custom comparator 사용
- 시간복잡도: O(N + K log N)
    - O(N) => Hash Map / Max Heap
    - O(K log N) => pop 연산(O(log N)) * k번
- 공간복잡도: O(N)
    - Hash Map / Max Heap

### Min Heap ver.

- Heaps > Finding Values in Sorted Order > Min Heap
    - Max Heap ver.에서 더 나아가, Heap의 공간복잡도를 더 줄일 수 있는 방법!
        - Heap의 공간복잡도: O(N) -> O(K)
    - Heap의 크기를 k 이하로 유지시키자!
        - 사실상 상위 k개를 제외하고는, 그 이하 순위들은 절대 답이 될리가 없다.
        - Heap의 크기가 k를 넘어설 때마다 아랫 순위들은 버리자.
    - Min Heap
        - '버릴 아랫 순위'를 식별 가능
    - 최종 답(`result`) => min heap의 역순서
- 시간복잡도: O(N log K)
    - Map 생성 => O(N)
    - Min Heap 생성 (push & pop) => O(N log K)
    - Min Heap -> result 옮겨 담기 => O(K log K)
    - result 역순서 => O(K)
    - O(N) + O(N log K) + O(K log K) + O(K) = O(N log K)
- 공간복잡도: O(N)
    - Map => O(N)
    - Min Heap => O(K)